### PR TITLE
Remove unnecessary npm package from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
     "express": "^4.16.3",
-    "mongoose": "^5.1.4",
-    "moongoose": "0.0.5"
+    "mongoose": "^5.1.4"
   }
 }


### PR DESCRIPTION
Don't be alarmed! I must have made a typo when I installed the first packages, so we have a ***moon*goose** on there, and this is just to get rid of it.