### PR TITLE
Break long strings in chirps so they don't stretch out the page

### DIFF
--- a/public/css/timeline.css
+++ b/public/css/timeline.css
@@ -288,6 +288,7 @@ textarea:focus {
 
 .chirp-content__body {
   margin: 10px 0px;
+  word-break: break-word;
 }
 
 .chirp-content__likes-container {


### PR DESCRIPTION
If you type in a long string without spaces into the chirp form, it stretches out the page horizontally once the chirp shows up on the timeline. I added a line in the CSS so the chirp breaks onto new lines (with words in tact).