### PR TITLE
made styling changes for mobile viewing

### DIFF
--- a/public/css/timeline.css
+++ b/public/css/timeline.css
@@ -10,7 +10,7 @@ body {
 
 .alignedToMainGrid {
   max-width: 1190px;
-  min-width: 1190px;
+  min-width: 320px;
   margin: 0 auto;
 }
 
@@ -85,6 +85,7 @@ body {
 .sidebar-right-gecko {
   background-color: #fff;
   height: 300px; 
+  margin-right: 15px;
 } 
 
 .sidebar-right-footer {
@@ -159,6 +160,7 @@ img {
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;
+  padding: 15px; 
 }
 
 .editProfile-button {


### PR DESCRIPTION
I've decided to make a new PR for the reasons of removing sensitive data from index.js and removing unnecessary local commits. 

Here are the reasons for changes to timeline.css

Problem 1:
- when viewing app on **mobile** resolutions there are some spacing issues with the hero blue bar, edit profile and gecko image.
![screenshot_2018-08-01-12-49-25](https://user-images.githubusercontent.com/30478409/43560833-30dd35f0-95c9-11e8-8bac-75364ff9c547.png)

Solution 1:
- made minor styling changes in timeline.css for better mobile viewing
<img width="785" alt="screen shot 2018-08-01 at 8 27 27 pm" src="https://user-images.githubusercontent.com/30478409/43560913-7cae7340-95c9-11e8-8f5f-2ef545ee1735.png">

 Problem 2:
- unnecessary commits from local dev was ahead of origin/dev" therefore being display on Github PR request
<img width="477" alt="screen shot 2018-08-01 at 7 59 17 pm" src="https://user-images.githubusercontent.com/30478409/43561002-dc01a510-95c9-11e8-974d-c9f26795545b.png">
<img width="711" alt="screen shot 2018-08-01 at 8 42 35 pm" src="https://user-images.githubusercontent.com/30478409/43561358-8de90632-95cb-11e8-9149-c3903ee96da1.png">

Solution 2:
- removed all local commits to reset local dev to origin/dev
`git reset --hard origin/dev`


